### PR TITLE
Make api-key data more generic in order to attach more info to it

### DIFF
--- a/src/lua/api-gateway/validation/validator.lua
+++ b/src/lua/api-gateway/validation/validator.lua
@@ -100,7 +100,6 @@ function BaseValidator:getKeyFromRedis(key, hash_name)
     if ok then
         local redis_key, selecterror = redisread:hget(key, hash_name)
         redisread:set_keepalive(30000, 100)
-        --ngx.log(ngx.WARN, "GOT REDIS RESPONSE:" .. type(redis_key));
         if (type(redis_key) == 'string') then
             return redis_key
         end
@@ -122,7 +121,9 @@ function BaseValidator:setKeyInRedis(key, hash_name, keyexpires, value)
         --ngx.log(ngx.DEBUG, "WRITING IN REDIS JSON OBJ key=" .. key .. "=" .. value .. ",expiring in:" .. (keyexpires - (os.time() * 1000)) )
         rediss:init_pipeline()
         rediss:hset(key, hash_name, value)
-        rediss:pexpireat(key, keyexpires)
+        if keyexpires ~= nil then
+            rediss:pexpireat(key, keyexpires)
+        end
         local commit_res, commit_err = rediss:commit_pipeline()
         rediss:set_keepalive(30000, 100)
         --ngx.log(ngx.WARN, "SAVE RESULT:" .. cjson.encode(commit_res) )

--- a/test/perl/api-gateway/validation/key/api_key_deprecated.t
+++ b/test/perl/api-gateway/validation/key/api_key_deprecated.t
@@ -1,0 +1,253 @@
+#/*
+# * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included in
+# * all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# * DEALINGS IN THE SOFTWARE.
+# *
+# */
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use lib 'lib';
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 4) + 14;
+
+my $pwd = cwd();
+
+our $HttpConfig = <<_EOC_;
+    # lua_package_path "$pwd/scripts/?.lua;;";
+    lua_package_path "src/lua/?.lua;/usr/local/lib/lua/?.lua;;";
+    init_by_lua '
+        local v = require "jit.v"
+        v.on("$Test::Nginx::Util::ErrLogFile")
+        require "resty.core"
+    ';
+     init_worker_by_lua '
+        ngx.apiGateway = ngx.apiGateway or {}
+        ngx.apiGateway.validation = require "api-gateway.validation.factory"
+     ';
+    lua_shared_dict cachedkeys 50m; # caches api-keys
+    include ../../api-gateway/redis-upstream.conf;
+_EOC_
+
+#no_diff();
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: test api_key is saved in redis
+--- http_config eval: $::HttpConfig
+--- config
+        include ../../api-gateway/api_key_service_deprecated.conf;
+        error_log ../test-logs/api_key_test1_error.log debug;
+
+--- more_headers
+X-Test: test
+--- request
+POST /cache/api_key?key=k-123&service_id=s-123
+--- response_body eval
+["+OK\r\n"]
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 2: check request without api_key parameter is rejected
+--- http_config eval: $::HttpConfig
+--- config
+        include ../../api-gateway/api_key_service_deprecated.conf;
+        include ../../api-gateway/default_validators.conf;
+        error_log ../test-logs/api_key_test2_error.log debug;
+
+        location /test-api-key {
+            set $service_id s-123;
+
+            set $api_key $arg_api_key;
+            set_if_empty $api_key $http_x_api_key;
+
+            set $validate_api_key on;
+
+            access_by_lua "ngx.apiGateway.validation.validateRequest()";
+            content_by_lua "ngx.say('api-key is valid.')";
+        }
+--- request
+GET /test-api-key
+--- response_body_like: {"error_code":"403000","message":"Api Key is required"}
+--- error_code: 403
+--- no_error_log
+[error]
+
+=== TEST 3: check request with invalid api_key is rejected
+--- http_config eval: $::HttpConfig
+--- config
+        include ../../api-gateway/api_key_service_deprecated.conf;
+        include ../../api-gateway/default_validators.conf;
+        error_log ../test-logs/api_key_test3_error.log debug;
+
+        location /test-api-key {
+            set $service_id s-123;
+
+            set $api_key $arg_api_key;
+            set_if_empty $api_key $http_x_api_key;
+
+            set $validate_api_key on;
+
+            access_by_lua "ngx.apiGateway.validation.validateRequest()";
+            content_by_lua "ngx.say('api-key is valid.')";
+        }
+--- request
+GET /test-api-key?api_key=ab123
+--- response_body_like: {"error_code":"403003","message":"Api Key is invalid"}
+--- error_code: 403
+--- no_error_log
+[error]
+
+=== TEST 4: test request with valid api_key
+--- http_config eval: $::HttpConfig
+--- config
+        include ../../api-gateway/api_key_service_deprecated.conf;
+        include ../../api-gateway/default_validators.conf;
+        error_log ../test-logs/api_key_test4_error.log debug;
+
+        location /test-api-key {
+            set $service_id s-123;
+
+            set $api_key $arg_api_key;
+            set_if_empty $api_key $http_x_api_key;
+
+            set $validate_api_key on;
+
+            access_by_lua "ngx.apiGateway.validation.validateRequest()";
+            content_by_lua "ngx.say('api-key is valid.')";
+        }
+--- pipelined_requests eval
+["POST /cache/api_key?key=test-key-1234&service_id=s-123",
+"GET /test-api-key?api_key=test-key-1234",
+"GET /test-api-key?api_key=test-key-1234"]
+--- response_body eval
+["+OK\r\n",
+"api-key is valid.\n",
+"api-key is valid.\n"
+]
+--- no_error_log
+
+
+=== TEST 5: test that api_key fields are saved in the request variables
+--- http_config eval: $::HttpConfig
+--- config
+        include ../../api-gateway/api_key_service_deprecated.conf;
+        include ../../api-gateway/default_validators.conf;
+        error_log ../test-logs/api_key_test5_error.log debug;
+
+        location /test-api-key-5 {
+            set $service_id s-123;
+
+            set $api_key $arg_api_key;
+            set_if_empty $api_key $http_x_api_key;
+
+            set $validate_api_key on;
+
+            access_by_lua "ngx.apiGateway.validation.validateRequest()";
+            content_by_lua "
+                ngx.say('service_name=' .. ngx.var.service_name .. ',consumer_org_name=' .. ngx.var.consumer_org_name .. ',app_name=' .. ngx.var.app_name .. ',secret=' .. tostring(ngx.var.key_secret) )
+            ";
+        }
+--- pipelined_requests eval
+["POST /cache/api_key?key=test-key-12345&service_id=s-123&service_name=test-service-name&consumer_org_name=test-consumer-name&app_name=test-app-name&secret=my-secret",
+"GET /cache/api_key/get?key=test-key-12345&service_id=s-123",
+"GET /test-api-key-5?api_key=test-key-12345"]
+--- response_body eval
+["+OK\r\n",
+'{"valid":true}' . "\n",
+"service_name=test-service-name,consumer_org_name=test-consumer-name,app_name=test-app-name,secret=my-secret\n"]
+--- no_error_log
+
+
+=== TEST 6: test debug headers
+--- http_config eval: $::HttpConfig
+--- config
+        include ../../api-gateway/api_key_service_deprecated.conf;
+        include ../../api-gateway/default_validators.conf;
+        error_log ../test-logs/api_key_test6_error.log debug;
+
+        location /test-api-key {
+            set $service_id s-123;
+
+            set $api_key $arg_api_key;
+            set_if_empty $api_key $http_x_api_key;
+
+            set $validate_api_key on;
+
+            access_by_lua "ngx.apiGateway.validation.validateRequest()";
+            content_by_lua "ngx.say('api-key is valid.')";
+        }
+--- pipelined_requests eval
+["POST /cache/api_key?key=test-key-123&service_id=s-123",
+"GET /test-api-key?api_key=test-key-123&debug=true"]
+--- response_body eval
+["+OK\r\n",
+"api-key is valid.\n"]
+--- response_headers_like eval
+[
+"",
+"X-Debug-Validation-Response-Times: /validate_api_key, \\d+ ms, status:200, request_validator \\[order:1\\], \\d+ ms, status:200"
+]
+--- no_error_log
+[error]
+
+
+=== TEST 7: test api-key related field starting with capital H
+--- http_config eval: $::HttpConfig
+--- config
+        include ../../api-gateway/api_key_service_deprecated.conf;
+        include ../../api-gateway/default_validators.conf;
+        error_log ../test-logs/api_key_test7_error.log debug;
+
+        location /test-api-key {
+            set $service_id hH-123;
+
+            set $api_key $arg_api_key;
+            set_if_empty $api_key $http_x_api_key;
+
+            set $validate_api_key on;
+
+            access_by_lua "ngx.apiGateway.validation.validateRequest()";
+            content_by_lua "ngx.say('api-key is valid.')";
+        }
+--- pipelined_requests eval
+[
+"POST /cache/api_key?key=test-key-1234_HHH&service_id=hH-123&app_name=hHHH",
+"GET /test-api-key?api_key=test-key-1234_HHH&debug=true"]
+--- response_body eval
+[
+"+OK\r\n",
+"api-key is valid.\n"]
+--- response_headers_like eval
+[
+"",
+"X-Debug-Validation-Response-Times: /validate_api_key, \\d+ ms, status:200, request_validator \\[order:1\\], \\d+ ms, status:200"
+]
+--- no_error_log
+[error]
+

--- a/test/perl/api-gateway/validation/signing/hmacGenericSignatureValidator.t
+++ b/test/perl/api-gateway/validation/signing/hmacGenericSignatureValidator.t
@@ -121,7 +121,17 @@ __DATA__
 ]
 --- response_body eval
 [
-"+OK\r\n",
+'{
+            "key":"test-key-1234",
+            "key_secret":"-",
+            "realm":"sandbox",
+            "service_id":"s-123",
+            "service_name":"_undefined_",
+            "consumer_org_name":"_undefined_",
+            "app_name":"_undefined_",
+            "plan_name":"_undefined_"
+            }
+',
 "signature is valid\n"
 ]
 --- error_code_like eval
@@ -162,7 +172,17 @@ __DATA__
 ]
 --- response_body eval
 [
-"+OK\r\n",
+'{
+            "key":"sZ28nvYnStSUS2dSzedgnwkJtUdLkNdR",
+            "key_secret":"mO2AIfdUQeQFiGQq",
+            "realm":"sandbox",
+            "service_id":"s-123",
+            "service_name":"_undefined_",
+            "consumer_org_name":"_undefined_",
+            "app_name":"_undefined_",
+            "plan_name":"_undefined_"
+            }
+',
 "signature is valid\n"
 ]
 --- error_code_like eval
@@ -170,10 +190,10 @@ __DATA__
 --- no_error_log
 [error]
 
-=== TEST 4: test HMAC SHA1 validator with API KEY validation
+=== TEST 4: test HMAC SHA1 validator with API KEY validation with deprecated API-KEY API
 --- http_config eval: $::HttpConfig
 --- config
-        include ../../api-gateway/api_key_service.conf;
+        include ../../api-gateway/api_key_service_deprecated.conf;
         include ../../api-gateway/default_validators.conf;
 
         location /v1.0/accounts/ {
@@ -260,7 +280,17 @@ __DATA__
 ]
 --- response_body eval
 [
-"+OK\r\n",
+'{
+            "key":"sZ28nvYnStSUS2dSzedgnwkJtUdLkNdR",
+            "key_secret":"mO2AIfdUQeQFiGQq",
+            "realm":"sandbox",
+            "service_id":"s-123",
+            "service_name":"_undefined_",
+            "consumer_org_name":"_undefined_",
+            "app_name":"_undefined_",
+            "plan_name":"_undefined_"
+            }
+',
 "signature is valid\n",
 'while (1) {}{"code":1033,"description":"Developer key missing or invalid"}' . "\n",
 'while (1) {}{"code":1033,"description":"Developer key missing or invalid"}' . "\n",
@@ -325,7 +355,17 @@ __DATA__
 ]
 --- response_body eval
 [
-"+OK\r\n",
+'{
+            "key":"sZ28nvYnStSUS2dSzedgnwkJtUdLkNdR",
+            "key_secret":"mO2AIfdUQeQFiGQq",
+            "realm":"sandbox",
+            "service_id":"123456",
+            "service_name":"_undefined_",
+            "consumer_org_name":"_undefined_",
+            "app_name":"_undefined_",
+            "plan_name":"_undefined_"
+            }
+',
 "5XPFapKr91/nLn3F+tzfkvSuE4A=\n",
 'while (1) {}{"code":1033,"description":"Developer key missing or invalid"}' . "\n",
 'while (1) {}{"code":1033,"description":"Developer key missing or invalid"}' . "\n",

--- a/test/resources/api-gateway/api_key_service_deprecated.conf
+++ b/test/resources/api-gateway/api_key_service_deprecated.conf
@@ -1,5 +1,5 @@
 #/*
-# * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+# * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a
 # * copy of this software and associated documentation files (the "Software"),
@@ -65,25 +65,9 @@ location ~ /cache/api_key/set {
     set_if_empty $app_name _undefined_;
     set_if_empty $plan_name _undefined_;
 
-    set $metadata '{
-            "key":"$key",
-            "key_secret":"$key_secret",
-            "realm":"$realm",
-            "service_id":"$service_id",
-            "service_name":"$service_name",
-            "consumer_org_name":"$consumer_org_name",
-            "app_name":"$app_name",
-            "plan_name":"$plan_name"
-            }';
+    set $redis_cmd "HMSET cachedkey:$key:$service_id key_secret $key_secret service-id $service_id service-name $service_name realm $realm consumer-org-name $consumer_org_name app-name $app_name plan-name $plan_name";
 
-    default_type application/json;
-
-    content_by_lua '
-        local BaseValidator = require "api-gateway.validation.validator"
-        local validator = BaseValidator:new()
-        validator:setKeyInRedis("cachedkey:" .. ngx.var.key .. ":" .. ngx.var.service_id, "metadata", nil, ngx.var.metadata)
-        ngx.say(ngx.var.metadata)
-    ';
+    proxy_pass http://127.0.0.1:$server_port/cache/redis_query?$redis_cmd;
 
     header_filter_by_lua '
         ngx.header.Description="Method used to add a new API-KEY into the cache. ";
@@ -131,6 +115,9 @@ location ~ /cache/api_key/get {
 
     set $api_key $arg_key;
     set $service_id $arg_service_id;
+
+    # set $redis_cmd "HMGET cachedkey:$key:$service_id service-id service-name realm consumer-org-name app-name plan-name";
+    # proxy_pass http://127.0.0.1:9191/cache/redis_query?$redis_cmd;
 
     header_filter_by_lua '
         ngx.header.Description="Retrieves all the fields of the key associated to the service_id parameter.";


### PR DESCRIPTION
This is a NON-BREAKING change. The old API still works, but the new one is executed first. If the API-KEY hasn't been defined in the new format ( as JSON ), it would read the old format ( individual Redis fields ). 

In the old format all the fields associated with an API-KEY were stored using `HMSET` i.e.

```
HMSET cachedkey:$key:$service_id service-id $service_id
```

In the new format we're using the same Redis Key but we're storing the metadata into a new field called `metadata`, using `HSET`. This field stores a JSON string. 

Since both `HSET` and `HMSET` are working on the same Redis Key the new implementation is additive and non breaking, as it simply adds a new field to the existing hash. If `HGET cachedkey:$key:$service_id metadata` returns the JSON, its value is used, else the API-KEY validator will try to do an `HMGET` on the other fields.
