### PR TITLE
Added support for runtime customizaiton of the oauth token validator

### DIFF
--- a/src/lua/api-gateway/validation/factory.lua
+++ b/src/lua/api-gateway/validation/factory.lua
@@ -101,9 +101,9 @@ local function _generateHmacSignature()
     return hmacSignatureValidator:generateSignature()
 end
 
-local function _validateOAuthToken(obj)
-    local oauthTokenValidator = OAuthTokenValidator:new()
-    return oauthTokenValidator:validateRequest(obj)
+local function _validateOAuthToken(config)
+    local oauthTokenValidator = OAuthTokenValidator:new(config)
+    return oauthTokenValidator:validateRequest()
 end
 
 local function _validateUserProfile()

--- a/src/lua/api-gateway/validation/factory.lua
+++ b/src/lua/api-gateway/validation/factory.lua
@@ -34,7 +34,6 @@
 -- Time: 23:36
 --
 
-local BaseValidator = require "api-gateway.validation.validator"
 local ValidatorsHandler = require "api-gateway.validation.validatorsHandler"
 local ApiKeyValidatorCls = require "api-gateway.validation.key.redisApiKeyValidator"
 local HmacSignatureValidator = require "api-gateway.validation.signing.hmacGenericSignatureValidator"
@@ -104,7 +103,7 @@ end
 
 local function _validateOAuthToken(obj)
     local oauthTokenValidator = OAuthTokenValidator:new()
-    BaseValidator:exitFn(oauthTokenValidator:validateRequest(obj))
+    return oauthTokenValidator:validateRequest(obj)
 end
 
 local function _validateUserProfile()

--- a/src/lua/api-gateway/validation/factory.lua
+++ b/src/lua/api-gateway/validation/factory.lua
@@ -34,6 +34,7 @@
 -- Time: 23:36
 --
 
+local BaseValidator = require "api-gateway.validation.validator"
 local ValidatorsHandler = require "api-gateway.validation.validatorsHandler"
 local ApiKeyValidatorCls = require "api-gateway.validation.key.redisApiKeyValidator"
 local HmacSignatureValidator = require "api-gateway.validation.signing.hmacGenericSignatureValidator"
@@ -101,9 +102,9 @@ local function _generateHmacSignature()
     return hmacSignatureValidator:generateSignature()
 end
 
-local function _validateOAuthToken()
+local function _validateOAuthToken(obj)
     local oauthTokenValidator = OAuthTokenValidator:new()
-    return oauthTokenValidator:validateRequest()
+    BaseValidator:exitFn(oauthTokenValidator:validateRequest(obj))
 end
 
 local function _validateUserProfile()

--- a/src/lua/api-gateway/validation/oauth2/oauthTokenValidator.lua
+++ b/src/lua/api-gateway/validation/oauth2/oauthTokenValidator.lua
@@ -171,8 +171,8 @@ function _M:validateOAuthToken(validation_config)
     validation_config = validation_config or {}
     validation_config.RESPONSES = validation_config.RESPONSES or RESPONSES;
 
-    local oauth_token = validation_config.authtoken or ngx.var.authtoken
     local oauth_host = ngx.var.oauth_host
+    local oauth_token = validation_config.authtoken or ngx.var.authtoken
 
     if oauth_token == nil or oauth_token == "" then
         return validation_config.RESPONSES.MISSING_TOKEN.error_code, cjson.encode(validation_config.RESPONSES.MISSING_TOKEN)


### PR DESCRIPTION
Provides a little more flexibility in the OAuth token validator such that it is possible to support scenarios where you validate two tokens per request while using different error codes.

Still work in progress, but just wanted to open an early discussion.

@ddascal @andralungu ping
