### PR TITLE
Multiple Redis authentication sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ redis: all
 	echo " ... using REDIS_SERVER=$(REDIS_SERVER)"
 
 test-docker:
-	export REDIS_PASS_API_KEY=
 	echo "Running tests with docker, using NO password protection for Redis"
 	mkdir  -p $(BUILD_DIR)
 	mkdir  -p $(BUILD_DIR)/test-logs
@@ -66,7 +65,6 @@ test-docker:
 	rm -rf  ~/tmp/apiplatform/api-gateway-request-validation
 
 test-docker-with-password:
-	export REDIS_PASS_API_KEY=redisPasswordForTests
 	echo "running tests with docker, using password protected Redis instance"
 	mkdir  -p $(BUILD_DIR)
 	mkdir  -p $(BUILD_DIR)/test-logs

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ redis: all
 	echo " ... using REDIS_SERVER=$(REDIS_SERVER)"
 
 test-docker:
-	export REDIS_PASS=
+	export REDIS_PASS_API_KEY=
 	echo "Running tests with docker, using NO password protection for Redis"
 	mkdir  -p $(BUILD_DIR)
 	mkdir  -p $(BUILD_DIR)/test-logs
@@ -66,7 +66,7 @@ test-docker:
 	rm -rf  ~/tmp/apiplatform/api-gateway-request-validation
 
 test-docker-with-password:
-	export REDIS_PASS=redisPasswordForTests
+	export REDIS_PASS_API_KEY=redisPasswordForTests
 	echo "running tests with docker, using password protected Redis instance"
 	mkdir  -p $(BUILD_DIR)
 	mkdir  -p $(BUILD_DIR)/test-logs

--- a/src/lua/api-gateway/redis/redisConnectionConfiguration.lua
+++ b/src/lua/api-gateway/redis/redisConnectionConfiguration.lua
@@ -1,0 +1,27 @@
+--
+-- Created by IntelliJ IDEA.
+-- User: vdatcu
+-- Date: 04/08/2017
+-- Time: 11:54
+-- To change this template use File | Settings | File Templates.
+--
+
+
+local redisConf = {}
+
+redisConf["oauth"] = {
+    env_password_variable = "REDIS_PASS_OAUTH",
+    ro_upstream_name = "oauth-redis-ro-upstream",
+    rw_upstream_name = "oauth-redis-rw-upstream"
+}
+
+redisConf["apiKey"] = {
+    env_password_variable = "REDIS_PASS_API_KEY",
+    ro_upstream_name = "api-gateway-redis-replica",
+    rw_upstream_name = "api-gateway-redis"
+}
+
+return redisConf
+
+-- getConnection(type, readonly, override_options)
+-- override_options: upstream and password_env_variable

--- a/src/lua/api-gateway/redis/redisConnectionConfiguration.lua
+++ b/src/lua/api-gateway/redis/redisConnectionConfiguration.lua
@@ -22,6 +22,3 @@ redisConf["apiKey"] = {
 }
 
 return redisConf
-
--- getConnection(type, readonly, override_options)
--- override_options: upstream and password_env_variable

--- a/src/lua/api-gateway/redis/redisConnectionProvider.lua
+++ b/src/lua/api-gateway/redis/redisConnectionProvider.lua
@@ -97,7 +97,7 @@ function RedisConnectionProvider:getConnection(cache_type, read_only, override_o
     end
 
     local redisConfig = redisConfiguration[cache_type]
-    if redisConfig == nil or #redisConfig then
+    if redisConfig ~= nil or #redisConfig then
         local redisUpstream
         if read_only then
             redisUpstream = redisConfig["ro_upstream_name"]

--- a/src/lua/api-gateway/validation/key/redisApiKeyValidator.lua
+++ b/src/lua/api-gateway/validation/key/redisApiKeyValidator.lua
@@ -60,7 +60,7 @@ local RESPONSES = {
 --
 function ApiKeyValidator:getLegacyKeyFromRedis(redis_key)
     ngx.log(ngx.DEBUG, "Looking for a legacy api-key in Redis")
-    local ok, redis = redisConnectionProvider:getConnection()
+    local ok, redis = redisConnectionProvider:getConnection("apiKey")
 
     if ok then
         --local selectresult, selecterror = red:hgetall(redis_key);

--- a/src/lua/api-gateway/validation/key/redisApiKeyValidator.lua
+++ b/src/lua/api-gateway/validation/key/redisApiKeyValidator.lua
@@ -38,6 +38,7 @@ local BaseValidator = require "api-gateway.validation.validator"
 local cjson = require "cjson"
 
 local RedisConnectionProvider = require "api-gateway.redis.redisConnectionProvider"
+local RedisConnectionConfiguration = require "api-gateway.redis.redisConnectionConfiguration"
 
 local ApiKeyValidator = BaseValidator:new()
 local redisConnectionProvider = RedisConnectionProvider:new()
@@ -60,7 +61,12 @@ local RESPONSES = {
 --
 function ApiKeyValidator:getLegacyKeyFromRedis(redis_key)
     ngx.log(ngx.DEBUG, "Looking for a legacy api-key in Redis")
-    local ok, redis = redisConnectionProvider:getConnection("apiKey")
+    local connection_options = {
+        upstream = RedisConnectionConfiguration["apiKey"]["ro_upstream_name"],
+        password = os.getenv(RedisConnectionConfiguration["apiKey"]["env_password_variable"])
+    }
+
+    local ok, redis = redisConnectionProvider:getConnection(connection_options);
 
     if ok then
         --local selectresult, selecterror = red:hgetall(redis_key);

--- a/src/lua/api-gateway/validation/oauth2/userProfileValidator.lua
+++ b/src/lua/api-gateway/validation/oauth2/userProfileValidator.lua
@@ -49,6 +49,7 @@ local _M = BaseValidator:new()
 
 _M["redis_RO_upstream"] = "oauth-redis-ro-upstream"
 _M["redis_RW_upstream"] = "oauth-redis-rw-upstream"
+_M["redis_pass_env"] = "REDIS_PASS_OAUTH"
 
 local RESPONSES = {
     P_MISSING_TOKEN   = { error_code = "403020", message = "Oauth token is missing"         },

--- a/src/lua/api-gateway/validation/validator.lua
+++ b/src/lua/api-gateway/validation/validator.lua
@@ -102,7 +102,7 @@ function BaseValidator:getKeyFromRedis(key, hash_name)
         return self:getHashValueFromRedis(key, hash_name)
     end
 
-    local ok, redisread = redisConnectionProvider:getConnection(self.redis_RO_upstream);
+    local ok, redisread = redisConnectionProvider:getConnection("apiKey", true);
     if ok then
         local result, err = redisread:get(key)
         redisConnectionProvider:closeConnection(redisread)
@@ -124,7 +124,7 @@ end
 -- the method uses HGET redis command --
 -- it returns the value of the key, when found in the cache, nil otherwise --
 function BaseValidator:getHashValueFromRedis(key, hash_field)
-    local ok, redisread = redisConnectionProvider:getConnection(self.redis_RO_upstream)
+    local ok, redisread = redisConnectionProvider:getConnection("apiKey", true);
     if ok then
         local redis_key, selecterror = redisread:hget(key, hash_field)
         redisConnectionProvider:closeConnection(redisread)
@@ -140,7 +140,7 @@ end
 
 -- is wrapper over redis exists  but returns boolean instead
 function BaseValidator:exists(key)
-    local ok, redisread = redisConnectionProvider:getConnection();
+    local ok, redisread = redisConnectionProvider:getConnection("apiKey");
     if ok then
         local redis_key, selecterror = redisread:exists(key)
         redisConnectionProvider:closeConnection(redisread)
@@ -160,7 +160,7 @@ end
 -- it retuns true if the information is saved in the cache, false otherwise --
 function BaseValidator:setKeyInRedis(key, hash_name, keyexpires, value)
     ngx.log(ngx.DEBUG, "Storing in Redis the key [", tostring(key), "], expireat=", tostring(keyexpires), ", value=", tostring(value))
-    local ok, rediss = redisConnectionProvider:getConnection(self.redis_RW_upstream)
+    local ok, rediss = redisConnectionProvider:getConnection("apiKey", true)
     if ok then
         --ngx.log(ngx.DEBUG, "WRITING IN REDIS JSON OBJ key=" .. key .. "=" .. value .. ",expiring in:" .. (keyexpires - (os.time() * 1000)) )
         rediss:init_pipeline()
@@ -184,7 +184,7 @@ end
 
 function BaseValidator:deleteKeyFromRedis(key)
     ngx.log(ngx.DEBUG, "Deleting key from Redis: " .. key)
-    local ok, redis = redisConnectionProvider:getConnection(self.redis_RW_upstream);
+    local ok, redis = redisConnectionProvider:getConnection("apiKey", true)
     if ok then
         local redisResponse, err = redis:del(key)
         if err then
@@ -211,7 +211,7 @@ end
 -- TTL using LuaResty Redis
 function BaseValidator:executeTtl(key)
     ngx.log(ngx.DEBUG, "Getting upstream from:" .. self.redis_RW_upstream)
-    local ok, redis = redisConnectionProvider:getConnection(self.redis_RW_upstream)
+    local ok, redis = redisConnectionProvider:getConnection("apiKey", true)
     if ok then
         ngx.log(ngx.DEBUG, "Executing TTL for key:" .. key)
         local ttl, err = redis:ttl(key)

--- a/src/lua/api-gateway/validation/validator.lua
+++ b/src/lua/api-gateway/validation/validator.lua
@@ -140,7 +140,7 @@ end
 
 -- is wrapper over redis exists  but returns boolean instead
 function BaseValidator:exists(key)
-    local ok, redisread = redisConnectionProvider:getConnection("apiKey");
+    local ok, redisread = redisConnectionProvider:getConnection("apiKey", true);
     if ok then
         local redis_key, selecterror = redisread:exists(key)
         redisConnectionProvider:closeConnection(redisread)
@@ -160,7 +160,7 @@ end
 -- it retuns true if the information is saved in the cache, false otherwise --
 function BaseValidator:setKeyInRedis(key, hash_name, keyexpires, value)
     ngx.log(ngx.DEBUG, "Storing in Redis the key [", tostring(key), "], expireat=", tostring(keyexpires), ", value=", tostring(value))
-    local ok, rediss = redisConnectionProvider:getConnection("apiKey", true)
+    local ok, rediss = redisConnectionProvider:getConnection("apiKey", false)
     if ok then
         --ngx.log(ngx.DEBUG, "WRITING IN REDIS JSON OBJ key=" .. key .. "=" .. value .. ",expiring in:" .. (keyexpires - (os.time() * 1000)) )
         rediss:init_pipeline()
@@ -184,7 +184,7 @@ end
 
 function BaseValidator:deleteKeyFromRedis(key)
     ngx.log(ngx.DEBUG, "Deleting key from Redis: " .. key)
-    local ok, redis = redisConnectionProvider:getConnection("apiKey", true)
+    local ok, redis = redisConnectionProvider:getConnection("apiKey", false)
     if ok then
         local redisResponse, err = redis:del(key)
         if err then

--- a/test/docker-compose-with-password.yml
+++ b/test/docker-compose-with-password.yml
@@ -1,6 +1,6 @@
 gateway:
   environment:
-      - REDIS_PASS_API_KEY=${REDIS_PASS_API_KEY}
+      - REDIS_PASS_API_KEY=redisPasswordForTests
   image: adobeapiplatform/apigateway
   links:
     - redis:redis.docker
@@ -13,9 +13,9 @@ gateway:
 redis:
   image: redis:2.8
   environment:
-      - REDIS_PASS_API_KEY=${REDIS_PASS_API_KEY}
+      - REDIS_PASS_API_KEY=redisPasswordForTests
   volumes:
     - ../test/scripts:/tmp/scripts
-  entrypoint: /tmp/scripts/start-redis.sh
+  entrypoint: /tmp/scripts/start-redis.sh redisPasswordForTests
   ports:
   - "6379:6379"

--- a/test/docker-compose-with-password.yml
+++ b/test/docker-compose-with-password.yml
@@ -1,6 +1,7 @@
 gateway:
   environment:
       - REDIS_PASS_API_KEY=redisPasswordForTests
+      - REDIS_PASS_OAUTH=redisPasswordForTests
   image: adobeapiplatform/apigateway
   links:
     - redis:redis.docker
@@ -14,6 +15,7 @@ redis:
   image: redis:2.8
   environment:
       - REDIS_PASS_API_KEY=redisPasswordForTests
+      - REDIS_PASS_OAUTH=redisPasswordForTests
   volumes:
     - ../test/scripts:/tmp/scripts
   entrypoint: /tmp/scripts/start-redis.sh redisPasswordForTests

--- a/test/docker-compose-with-password.yml
+++ b/test/docker-compose-with-password.yml
@@ -1,6 +1,6 @@
 gateway:
   environment:
-      - REDIS_PASSWORD=${REDIS_PASS}
+      - REDIS_PASS_API_KEY=${REDIS_PASS_API_KEY}
   image: adobeapiplatform/apigateway
   links:
     - redis:redis.docker
@@ -13,7 +13,7 @@ gateway:
 redis:
   image: redis:2.8
   environment:
-      - REDIS_PASSWORD=${REDIS_PASS}
+      - REDIS_PASS_API_KEY=${REDIS_PASS_API_KEY}
   volumes:
     - ../test/scripts:/tmp/scripts
   entrypoint: /tmp/scripts/start-redis.sh

--- a/test/perl/api-gateway/validation/key/apiKeyValidator.t
+++ b/test/perl/api-gateway/validation/key/apiKeyValidator.t
@@ -61,7 +61,6 @@ __DATA__
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -94,7 +93,6 @@ POST /cache/api_key?key=key-123&service_id=s-123
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -125,7 +123,6 @@ GET /test-api-key
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -155,7 +152,6 @@ GET /test-api-key?api_key=ab123
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -200,7 +196,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -246,7 +241,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -294,7 +288,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -345,7 +338,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config

--- a/test/perl/api-gateway/validation/key/apiKeyValidator.t
+++ b/test/perl/api-gateway/validation/key/apiKeyValidator.t
@@ -61,6 +61,7 @@ __DATA__
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -93,6 +94,7 @@ POST /cache/api_key?key=key-123&service_id=s-123
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -123,6 +125,7 @@ GET /test-api-key
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -152,6 +155,7 @@ GET /test-api-key?api_key=ab123
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -196,6 +200,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -241,6 +246,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -288,6 +294,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -338,6 +345,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config

--- a/test/perl/api-gateway/validation/key/apiKeyValidator.t
+++ b/test/perl/api-gateway/validation/key/apiKeyValidator.t
@@ -60,7 +60,7 @@ __DATA__
 === TEST 1: test api_key is saved in redis
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -93,7 +93,7 @@ POST /cache/api_key?key=key-123&service_id=s-123
 === TEST 2: check request without api_key parameter is rejected
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -124,7 +124,7 @@ GET /test-api-key
 === TEST 3: check request with invalid api_key is rejected
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -154,7 +154,7 @@ GET /test-api-key?api_key=ab123
 === TEST 4: test request with valid api_key
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -199,7 +199,7 @@ env REDIS_PASS;
 === TEST 5: test that api_key fields are saved in the request variables
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -245,7 +245,7 @@ env REDIS_PASS;
 === TEST 6: test debug headers
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -293,7 +293,7 @@ env REDIS_PASS;
 === TEST 7: test api-key related field starting with capital H
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -344,7 +344,7 @@ env REDIS_PASS;
 === TEST 8: test with more api-key fields
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig

--- a/test/perl/api-gateway/validation/oauth2/oauthTokenValidator.t
+++ b/test/perl/api-gateway/validation/oauth2/oauthTokenValidator.t
@@ -64,7 +64,6 @@ __DATA__
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -104,7 +103,6 @@ GET /test-oauth-validation
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -207,7 +205,6 @@ Authorization: Bearer SOME_OAUTH_TOKEN_TEST_2_X_0
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -271,7 +268,6 @@ Authorization: Bearer SOME_OAUTH_TOKEN_TEST3
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -368,7 +364,6 @@ Authorization: Bearer SOME_OAUTH_TOKEN_TEST4
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -409,7 +404,6 @@ GET /test-oauth-validation
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config

--- a/test/perl/api-gateway/validation/oauth2/oauthTokenValidator.t
+++ b/test/perl/api-gateway/validation/oauth2/oauthTokenValidator.t
@@ -64,6 +64,7 @@ __DATA__
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -103,6 +104,7 @@ GET /test-oauth-validation
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -136,6 +138,7 @@ env REDIS_PASS_API_KEY;
                 local TestValidator = BaseValidator:new()
                 TestValidator["redis_RO_upstream"] = "oauth-redis-ro-upstream"
                 TestValidator["redis_RW_upstream"] = "oauth-redis-rw-upstream"
+                TestValidator["redis_pass_env"] = "REDIS_PASS_OAUTH"
                 local validator = TestValidator:new()
                 local res = validator:getKeyFromRedis(ngx.var.key, "token_json")
                 if ( res ~= nil) then
@@ -205,6 +208,7 @@ Authorization: Bearer SOME_OAUTH_TOKEN_TEST_2_X_0
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -268,6 +272,7 @@ Authorization: Bearer SOME_OAUTH_TOKEN_TEST3
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -364,6 +369,7 @@ Authorization: Bearer SOME_OAUTH_TOKEN_TEST4
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -404,6 +410,7 @@ GET /test-oauth-validation
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config

--- a/test/perl/api-gateway/validation/oauth2/oauthTokenValidator.t
+++ b/test/perl/api-gateway/validation/oauth2/oauthTokenValidator.t
@@ -63,7 +63,7 @@ __DATA__
 === TEST 1: test ims_token is validated correctly
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -103,7 +103,7 @@ GET /test-oauth-validation
 === TEST 2: test ims_token is saved in the cache
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -206,7 +206,7 @@ Authorization: Bearer SOME_OAUTH_TOKEN_TEST_2_X_0
 === TEST 3: test oauth vars are saved in request variables
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -270,7 +270,7 @@ Authorization: Bearer SOME_OAUTH_TOKEN_TEST3
 === TEST 4: test IMS token is saved in redis and in the local cache
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -367,7 +367,7 @@ Authorization: Bearer SOME_OAUTH_TOKEN_TEST4
 === TEST 5: test invalid token returns 401
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -408,7 +408,7 @@ GET /test-oauth-validation
 === TEST 6: test that validation behaviour can be customized
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig

--- a/test/perl/api-gateway/validation/oauth2/userProfileValidator.t
+++ b/test/perl/api-gateway/validation/oauth2/userProfileValidator.t
@@ -31,7 +31,7 @@ use Cwd qw(cwd);
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 8 ) - 12;
+plan tests => repeat_each() * (blocks() * 8) - 12;
 
 my $pwd = cwd();
 
@@ -66,6 +66,7 @@ __DATA__
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -97,6 +98,7 @@ env REDIS_PASS_API_KEY;
                 local v = BaseValidator:new()
                 v["redis_RO_upstream"] = "oauth-redis-ro-upstream"
                 v["redis_RW_upstream"] = "oauth-redis-rw-upstream"
+                v["redis_pass_env"] = "REDIS_PASS_OAUTH"
                 local k = v:getKeyFromLocalCache(ngx.var.key,"cachedUserProfiles")
                 v:exitFn(200,"Local: " .. tostring(k))
             ';
@@ -113,6 +115,7 @@ env REDIS_PASS_API_KEY;
                 local v = BaseValidator:new()
                 v["redis_RO_upstream"] = "oauth-redis-ro-upstream"
                 v["redis_RW_upstream"] = "oauth-redis-rw-upstream"
+                v["redis_pass_env"] = "REDIS_PASS_OAUTH"
                 local k = v:getKeyFromRedis(ngx.var.key,"user_json")
                 v:exitFn(200,"Redis: " .. tostring(k))
             ';
@@ -141,6 +144,7 @@ Authorization: Bearer SOME_OAUTH_PROFILE_TEST_1
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -168,6 +172,7 @@ env REDIS_PASS_API_KEY;
                 local v = BaseValidator:new()
                 v["redis_RO_upstream"] = "oauth-redis-ro-upstream"
                 v["redis_RW_upstream"] = "oauth-redis-rw-upstream"
+                v["redis_pass_env"] = "REDIS_PASS_OAUTH"
                 local k = v:getKeyFromLocalCache("cachedoauth:8cd12eadb5032aa2153c8f830d01e0be","cachedUserProfiles")
                 v:exitFn(200,k)
             ';
@@ -179,6 +184,7 @@ env REDIS_PASS_API_KEY;
                 local v = BaseValidator:new()
                 v["redis_RO_upstream"] = "oauth-redis-ro-upstream"
                 v["redis_RW_upstream"] = "oauth-redis-rw-upstream"
+                v["redis_pass_env"] = "REDIS_PASS_OAUTH"
                 local k = v:getKeyFromRedis("cachedoauth:8cd12eadb5032aa2153c8f830d01e0be","user_json")
                 v:exitFn(200,k)
             ';
@@ -212,6 +218,7 @@ Authorization: Bearer SOME_OAUTH_TOKEN_TEST_TWO
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -264,6 +271,7 @@ X-User-Name: display_name-%E5%B7%A5%EF%BC%8D%E5%A5%B3%EF%BC%8D%E9%95%BF
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -310,6 +318,7 @@ X-User-Name: display_name-%E5%B7%A5%EF%BC%8D%E5%A5%B3%EF%BC%8D%E9%95%BF
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config

--- a/test/perl/api-gateway/validation/oauth2/userProfileValidator.t
+++ b/test/perl/api-gateway/validation/oauth2/userProfileValidator.t
@@ -63,6 +63,10 @@ run_tests();
 __DATA__
 
 === TEST 1: test ims_profile is saved correctly in cache and in request variables
+
+--- main_config
+env REDIS_PASS_API_KEY;
+
 --- http_config eval: $::HttpConfig
 --- config
         include ../../api-gateway/api-gateway-cache.conf;
@@ -134,6 +138,10 @@ Authorization: Bearer SOME_OAUTH_PROFILE_TEST_1
 [error]
 
 === TEST 2: test ims_profile is saved correctly in cache and in request variables
+
+--- main_config
+env REDIS_PASS_API_KEY;
+
 --- http_config eval: $::HttpConfig
 --- config
         include ../../api-gateway/api-gateway-cache.conf;
@@ -201,6 +209,10 @@ Authorization: Bearer SOME_OAUTH_TOKEN_TEST_TWO
 [error]
 
 === TEST 3: test ims_profile can add corresponding headers to request
+
+--- main_config
+env REDIS_PASS_API_KEY;
+
 --- http_config eval: $::HttpConfig
 --- config
         include ../../api-gateway/api-gateway-cache.conf;
@@ -249,6 +261,10 @@ X-User-Name: display_name-%E5%B7%A5%EF%BC%8D%E5%A5%B3%EF%BC%8D%E9%95%BF
 [error]
 
 === TEST 4: test ims_profile with a null field
+
+--- main_config
+env REDIS_PASS_API_KEY;
+
 --- http_config eval: $::HttpConfig
 --- config
         include ../../api-gateway/api-gateway-cache.conf;
@@ -291,6 +307,10 @@ X-User-Name: display_name-%E5%B7%A5%EF%BC%8D%E5%A5%B3%EF%BC%8D%E9%95%BF
 [error]
 
 === TEST 5: test ims_profile with a null name field
+
+--- main_config
+env REDIS_PASS_API_KEY;
+
 --- http_config eval: $::HttpConfig
 --- config
         include ../../api-gateway/api-gateway-cache.conf;

--- a/test/perl/api-gateway/validation/signing/hmacGenericSignatureValidator.t
+++ b/test/perl/api-gateway/validation/signing/hmacGenericSignatureValidator.t
@@ -62,7 +62,6 @@ __DATA__
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -89,7 +88,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -153,7 +151,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -209,7 +206,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -265,7 +261,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -341,7 +336,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -421,7 +415,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config

--- a/test/perl/api-gateway/validation/signing/hmacGenericSignatureValidator.t
+++ b/test/perl/api-gateway/validation/signing/hmacGenericSignatureValidator.t
@@ -61,7 +61,7 @@ __DATA__
 === TEST 1: test basic HMAC SHA1 signature validation
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -88,7 +88,7 @@ env REDIS_PASS;
 === TEST 2: test HMAC SHA1 validator with request validation
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -152,7 +152,7 @@ env REDIS_PASS;
 === TEST 3: test HMAC SHA1 validator with API KEY validation
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -208,7 +208,7 @@ env REDIS_PASS;
 === TEST 4: test HMAC SHA1 validator with API KEY validation with deprecated API-KEY API
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -264,7 +264,7 @@ env REDIS_PASS;
 === TEST 5: test HMAC SHA1 validator with API KEY validation and custom ERROR MESSAGES
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -340,7 +340,7 @@ env REDIS_PASS;
 === TEST 6: test HMAC signature validation and generation
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -420,7 +420,7 @@ env REDIS_PASS;
 === TEST 7: test HMAC digest in isolation
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig

--- a/test/perl/api-gateway/validation/signing/hmacGenericSignatureValidator.t
+++ b/test/perl/api-gateway/validation/signing/hmacGenericSignatureValidator.t
@@ -62,6 +62,7 @@ __DATA__
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -88,6 +89,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -151,6 +153,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -206,6 +209,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -261,6 +265,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -336,6 +341,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -415,6 +421,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config

--- a/test/perl/api-gateway/validation/validator.t
+++ b/test/perl/api-gateway/validation/validator.t
@@ -59,7 +59,6 @@ __DATA__
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -89,7 +88,6 @@ GET /test-base-validator
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -146,7 +144,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -204,7 +201,6 @@ env REDIS_PASS;
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -237,7 +233,6 @@ GET /test-base-validator
 
 --- main_config
 env REDIS_PASS_API_KEY;
-env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
 --- config

--- a/test/perl/api-gateway/validation/validator.t
+++ b/test/perl/api-gateway/validation/validator.t
@@ -58,7 +58,7 @@ __DATA__
 === TEST 1: test core validator initialization
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -88,7 +88,7 @@ GET /test-base-validator
 === TEST 2: test core validator local caching
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -145,7 +145,7 @@ env REDIS_PASS;
 === TEST 3: test core validator with Redis caching
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -203,7 +203,7 @@ env REDIS_PASS;
 === TEST 4: test setContextProperties with object
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig
@@ -236,7 +236,7 @@ GET /test-base-validator
 === TEST 5: test setContextProperties with string
 
 --- main_config
-env REDIS_PASSWORD;
+env REDIS_PASS_API_KEY;
 env REDIS_PASS;
 
 --- http_config eval: $::HttpConfig

--- a/test/perl/api-gateway/validation/validator.t
+++ b/test/perl/api-gateway/validation/validator.t
@@ -59,6 +59,7 @@ __DATA__
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -88,6 +89,7 @@ GET /test-base-validator
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -144,6 +146,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -201,6 +204,7 @@ env REDIS_PASS_API_KEY;
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config
@@ -233,6 +237,7 @@ GET /test-base-validator
 
 --- main_config
 env REDIS_PASS_API_KEY;
+env REDIS_PASS_OAUTH;
 
 --- http_config eval: $::HttpConfig
 --- config

--- a/test/scripts/start-redis.sh
+++ b/test/scripts/start-redis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Checking for Redis authentication"
-readonly redis_password="${REDIS_PASSWORD}"
+readonly redis_password=$1
 
 if [ -z ${redis_password} ]
 then


### PR DESCRIPTION
- Add multiple redis authentication sources
- Change the way connections are requested; now the caller should provide cluster_type, read_only if the connection is to be made using the existing mechanism, or provide override_options table if they want to go straight to the Redis instance, without upstream resolution
- The existing cluster types are "apiKey" and "oauth"; more can be added in the redisConnectionConfiguration file
- Replace env variable names