### PR TITLE
Logged execution times for redis methods.

### DIFF
--- a/src/lua/api-gateway/redis/redisConnectionProvider.lua
+++ b/src/lua/api-gateway/redis/redisConnectionProvider.lua
@@ -23,6 +23,7 @@
 local restyRedis = require "resty.redis"
 local RedisHealthCheck = require "api-gateway.redis.redisHealthCheck"
 local apiGatewayRedisReadReplica = "api-gateway-redis-replica"
+local Monitor = require "api-gateway.util.Monitor"
 
 local redisHealthCheck = RedisHealthCheck:new({
     shared_dict = "cachedkeys"
@@ -61,6 +62,11 @@ end
 -- Redis authentication
 function RedisConnectionProvider:getConnection(upstream)
     local redis = restyRedis:new()
+
+    -- Introduce monitoring
+    Monitor.decorateClass("restyRedis", redis, {"get", "hget", "connect", "exists", "hset", "del", "ttl"},
+        Monitor.decorateRedisCallsWithTimeElapsedFunction)
+
     local redis_host, redis_port = self:getRedisUpstream(upstream)
     local ok, err = redis:connect(redis_host, redis_port)
 

--- a/src/lua/api-gateway/util/Monitor.lua
+++ b/src/lua/api-gateway/util/Monitor.lua
@@ -1,0 +1,104 @@
+-- Copyright (c) 2017 Adobe Systems Incorporated. All rights reserved.
+--
+--   Permission is hereby granted, free of charge, to any person obtaining a
+--   copy of this software and associated documentation files (the "Software"),
+--   to deal in the Software without restriction, including without limitation
+--   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+--   and/or sell copies of the Software, and to permit persons to whom the
+--   Software is furnished to do so, subject to the following conditions:
+--
+--   The above copyright notice and this permission notice shall be included in
+--   all copies or substantial portions of the Software.
+--
+--   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+--   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+--   DEALINGS IN THE SOFTWARE.
+
+
+local Monitor = {
+    decorateFunction = nil,
+    decorateClass = nil,
+    decorateRedisCallsWithTimeElapsedFunction = nil
+}
+
+Monitor.decorateRedisCallsWithTimeElapsedFunction = function(name, fn)
+    return function(...)
+        local result
+        local single_result = false
+        local start_time, end_time, elapsed
+
+        if(name == "restyRedis:hset") then
+            start_time = os.clock()
+            single_result = true
+            result = fn(...)
+            end_time = os.clock()
+            elapsed = end_time - start_time
+            ngx.log(ngx.WARN, "Execution for: " .. name .. " took: " .. elapsed * 100000)
+        end
+
+        start_time = os.clock()
+        local ok, err = fn(...)
+        end_time = os.clock()
+        elapsed = end_time - start_time
+        ngx.log(ngx.WARN, "Execution for: " .. name .. " took: " .. elapsed * 100000)
+
+        if(single_result) then
+            return result
+        else
+            return ok, err
+        end
+    end
+end
+
+Monitor.decorateFunction = function(name, fn, decorationFunction)
+    if(not fn or type(fn) ~= 'function') then
+        return fn
+    end
+
+    if not decorationFunction or type(decorationFunction) ~= 'function' then
+        local localFn = function( ... )
+            print("start " .. name)
+            local result = fn(...)
+            print("end " .. name)
+            return result
+        end
+
+        return localFn
+    end
+
+    return decorationFunction(name, fn)
+end
+
+Monitor.decorateClass = function(name, class, methods, decorationFunction)
+    if(not class or type(class) ~= 'table') then
+        return class
+    end
+
+    methods = methods or {}
+
+    local all = false
+    if #methods == 0 then
+        all = true
+    end
+
+    if all then
+        for k, v in pairs(class) do
+            class[k] = Monitor.decorateFunction(name .. ":" .. k, v, decorationFunction)
+        end
+    else
+        for k, v in ipairs(methods) do
+            class[v] = Monitor.decorateFunction(name .. ":" .. v, class[v], decorationFunction)
+        end
+    end
+
+    return class
+end
+
+return Monitor
+
+
+

--- a/test/docker-compose-with-password.yml
+++ b/test/docker-compose-with-password.yml
@@ -1,21 +1,25 @@
-gateway:
-  environment:
-      - REDIS_PASSWORD=${REDIS_PASS}
-  image: adobeapiplatform/apigateway
-  links:
-    - redis:redis.docker
-  volumes:
-    - ~/tmp/apiplatform/api-gateway-request-validation/src/lua/api-gateway/validation:/usr/local/api-gateway/lualib/api-gateway/validation
-    - ~/tmp/apiplatform/api-gateway-request-validation/src/lua/api-gateway/redis:/usr/local/api-gateway/lualib/api-gateway/redis
-    - ~/tmp/apiplatform/api-gateway-request-validation/test/perl:/tmp/perl
-    - ~/tmp/apiplatform/api-gateway-request-validation/target/:/t
-  entrypoint: ["prove", "-I/usr/local/test-nginx-0.24/lib", "-I/usr/local/test-nginx-0.24/inc", "-r", "/tmp/perl/"]
-redis:
-  image: redis:2.8
-  environment:
-      - REDIS_PASSWORD=${REDIS_PASS}
-  volumes:
-    - ../test/scripts:/tmp/scripts
-  entrypoint: /tmp/scripts/start-redis.sh
-  ports:
-  - "6379:6379"
+version: '2.0'
+services:
+  gateway:
+    environment:
+        - REDIS_PASSWORD=${REDIS_PASS}
+    image: adobeapiplatform/apigateway
+    depends_on:
+      - redis
+    links:
+      - redis:redis.docker
+    volumes:
+      - ~/tmp/apiplatform/api-gateway-request-validation/src/lua/api-gateway/validation:/usr/local/api-gateway/lualib/api-gateway/validation
+      - ~/tmp/apiplatform/api-gateway-request-validation/src/lua/api-gateway/redis:/usr/local/api-gateway/lualib/api-gateway/redis
+      - ~/tmp/apiplatform/api-gateway-request-validation/test/perl:/tmp/perl
+      - ~/tmp/apiplatform/api-gateway-request-validation/target/:/t
+    entrypoint: ["prove", "-I/usr/local/test-nginx-0.24/lib", "-I/usr/local/test-nginx-0.24/inc", "-r", "/tmp/perl/"]
+  redis:
+    image: redis:2.8
+    environment:
+        - REDIS_PASSWORD=${REDIS_PASS}
+    volumes:
+      - ../test/scripts:/tmp/scripts
+    entrypoint: /tmp/scripts/start-redis.sh
+    ports:
+    - "6379:6379"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,17 +1,22 @@
-gateway:
-  image: adobeapiplatform/apigateway
-  links:
-    - redis:redis.docker
-  volumes:
-    - ~/tmp/apiplatform/api-gateway-request-validation/src/lua/api-gateway/validation:/usr/local/api-gateway/lualib/api-gateway/validation
-    - ~/tmp/apiplatform/api-gateway-request-validation/src/lua/api-gateway/redis:/usr/local/api-gateway/lualib/api-gateway/redis
-    - ~/tmp/apiplatform/api-gateway-request-validation/test/perl:/tmp/perl
-    - ../target/:/t
-  entrypoint: ["prove", "-I/usr/local/test-nginx-0.24/lib", "-I/usr/local/test-nginx-0.24/inc", "-r", "/tmp/perl/"]
-redis:
-  image: redis:2.8
-  volumes:
-    - ../test/scripts:/tmp/scripts
-  entrypoint: /tmp/scripts/start-redis.sh
-  ports:
-  - "6379:6379"
+version: '2.0'
+services:
+  gateway:
+    image: adobeapiplatform/apigateway
+    depends_on:
+      - redis
+    links:
+      - redis:redis.docker
+    volumes:
+      - ~/tmp/apiplatform/api-gateway-request-validation/src/lua/api-gateway/validation:/usr/local/api-gateway/lualib/api-gateway/validation
+      - ~/tmp/apiplatform/api-gateway-request-validation/src/lua/api-gateway/redis:/usr/local/api-gateway/lualib/api-gateway/redis
+      - ~/tmp/apiplatform/api-gateway-request-validation/src/lua/api-gateway/util:/usr/local/api-gateway/lualib/api-gateway/util
+      - ~/tmp/apiplatform/api-gateway-request-validation/test/perl:/tmp/perl
+      - ../target/:/t
+    entrypoint: ["prove", "-I/usr/local/test-nginx-0.24/lib", "-I/usr/local/test-nginx-0.24/inc", "-r", "/tmp/perl/"]
+  redis:
+    image: redis:2.8
+    volumes:
+      - ../test/scripts:/tmp/scripts
+    entrypoint: /tmp/scripts/start-redis.sh
+    ports:
+    - "6379:6379"


### PR DESCRIPTION
Sample log entry: 
`Monitor.lua:47: connect(): Execution for: restyRedis:connect took: 86.3, client: 127.0.0.1, server: localhost, request: "POST /cache/api_key?key=key-123&service_id=s-123 HTTP/1.1", host: "localhost"`

@atrifan, @cristianconstantin, @ddragosd please review.   
