### PR TITLE
[WS-11856] Fix logger decorator for callbacks

### DIFF
--- a/src/lua/api-gateway/util/logger.lua
+++ b/src/lua/api-gateway/util/logger.lua
@@ -1,14 +1,27 @@
 local set = false
 
-function getLogFormat(level, debugInfo, ...)
-    return level, "[", debugInfo.short_src,
-        ":", debugInfo.currentline,
-        ":", debugInfo.name,
-        "() req_id=", tostring(ngx.var.requestId),
-        "] ", ...
+local function is_in_init_phase()
+    return ngx.var.requestId
 end
 
-function _decorateLogger()
+local function getLogFormat(level, debugInfo, ...)
+    local status, result = pcall(is_in_init_phase)
+    if status then
+        return level, "[", debugInfo.short_src,
+        ":", debugInfo.currentline,
+        ":", debugInfo.name,
+        "() req_id=", tostring(result),
+        "] ", ...
+    else
+        return 'NOTICE', "[", debugInfo.short_src,
+        ":", debugInfo.currentline,
+        ":", debugInfo.name,
+        "() req_id=",
+        "] ", ...
+    end
+end
+
+local function _decorateLogger()
     if not set then
         local oldNgx = ngx.log
         ngx.log = function(level, ...)

--- a/src/lua/api-gateway/util/logger.lua
+++ b/src/lua/api-gateway/util/logger.lua
@@ -37,6 +37,7 @@ local function _decorateLogger()
         local oldNgx = ngx.log
         ngx.log = function(level, ...)
             -- gets the level 2 because level 1 is this function and I need my caller
+            -- nSl means line, name, source
             local debugInfo =  debug.getinfo(2, "nSl")
             pcall(function(...)
                 oldNgx(getLogFormat(level, debugInfo, ...))

--- a/src/lua/api-gateway/util/logger.lua
+++ b/src/lua/api-gateway/util/logger.lua
@@ -24,7 +24,7 @@ local function _decorateLogger()
     if not set then
         local oldNgx = ngx.log
         ngx.log = function(level, ...)
-            local debugInfo =  debug.getinfo(2)
+            local debugInfo =  debug.getinfo(2, "nSl")
             pcall(function(...)
                 oldNgx(getLogFormat(level, debugInfo, ...))
             end, ...)

--- a/src/lua/api-gateway/util/logger.lua
+++ b/src/lua/api-gateway/util/logger.lua
@@ -1,9 +1,20 @@
 local set = false
 
+---
+-- Checks and returns the ngx.var.requestId if possible
+-- ngx.var is not accessible in some nginx phases like init phase and so we also check this
+--
 local function is_in_init_phase()
     return ngx.var.requestId
 end
 
+---
+-- Get an error log format level, [file:currentline:function_name() req_id=<request_id>], message. This is passed to the
+-- original ngx.log function
+-- @param level - the log level like ngx.DEBUG, ngx.INFO, etc.
+-- @param debugInfo - the debug.getinfo() table needed for the stacktrace
+-- @param ... - other variables normally passed to ngx.log(), in general string concatenation
+--
 local function getLogFormat(level, debugInfo, ...)
     local status, request_id = pcall(is_in_init_phase)
     --- testing for init phase
@@ -18,6 +29,9 @@ local function getLogFormat(level, debugInfo, ...)
     "] ", ...
 end
 
+---
+-- Replaces the ngx.log function with the original ngx.log but redecorate the message
+--
 local function _decorateLogger()
     if not set then
         local oldNgx = ngx.log

--- a/src/lua/api-gateway/util/logger.lua
+++ b/src/lua/api-gateway/util/logger.lua
@@ -5,19 +5,16 @@ local function is_in_init_phase()
 end
 
 local function getLogFormat(level, debugInfo, ...)
-    local status, result = pcall(is_in_init_phase)
+    local status, request_id = pcall(is_in_init_phase)
     --- testing for init phase
-    if status then
-        return level, "[", debugInfo.short_src,
-        ":", debugInfo.currentline,
-        ":", debugInfo.name,
-        "() req_id=", tostring(result),
-        "] ", ...
+    if not status then
+       request_id = "N/A"
     end
+
     return level, "[", debugInfo.short_src,
     ":", debugInfo.currentline,
     ":", debugInfo.name,
-    "() req_id=",
+    "() req_id=", tostring(request_id),
     "] ", ...
 end
 

--- a/src/lua/api-gateway/util/logger.lua
+++ b/src/lua/api-gateway/util/logger.lua
@@ -36,6 +36,7 @@ local function _decorateLogger()
     if not set then
         local oldNgx = ngx.log
         ngx.log = function(level, ...)
+            -- gets the level 2 because level 1 is this function and I need my caller
             local debugInfo =  debug.getinfo(2, "nSl")
             pcall(function(...)
                 oldNgx(getLogFormat(level, debugInfo, ...))

--- a/src/lua/api-gateway/util/logger.lua
+++ b/src/lua/api-gateway/util/logger.lua
@@ -12,13 +12,12 @@ local function getLogFormat(level, debugInfo, ...)
         ":", debugInfo.name,
         "() req_id=", tostring(result),
         "] ", ...
-    else
-        return 'NOTICE', "[", debugInfo.short_src,
-        ":", debugInfo.currentline,
-        ":", debugInfo.name,
-        "() req_id=",
-        "] ", ...
     end
+    return 'NOTICE', "[", debugInfo.short_src,
+    ":", debugInfo.currentline,
+    ":", debugInfo.name,
+    "() req_id=",
+    "] ", ...
 end
 
 local function _decorateLogger()

--- a/src/lua/api-gateway/util/logger.lua
+++ b/src/lua/api-gateway/util/logger.lua
@@ -6,6 +6,7 @@ end
 
 local function getLogFormat(level, debugInfo, ...)
     local status, result = pcall(is_in_init_phase)
+    --- testing for init phase
     if status then
         return level, "[", debugInfo.short_src,
         ":", debugInfo.currentline,
@@ -13,7 +14,7 @@ local function getLogFormat(level, debugInfo, ...)
         "() req_id=", tostring(result),
         "] ", ...
     end
-    return 'NOTICE', "[", debugInfo.short_src,
+    return level, "[", debugInfo.short_src,
     ":", debugInfo.currentline,
     ":", debugInfo.name,
     "() req_id=",


### PR DESCRIPTION
As a developer i want to fix the logger decorator so all messages are logged.

Nothing that is executed in the kinesis callback is logged. The logger is enhanced with ngx.var.requestId but the timer callback is detached from the request's context and can not access this variable (see logger.lua from api-gateway-request-validation module);

the logger decorator can be improved by selecting what type of information should debug.getinfo return (line 15 from logger.lua file);
Suggested improvement:
local debugInfo =  debug.getinfo(2, "nSl")
Reference: https://www.lua.org/pil/23.1.html

