### PR TITLE
[WS-12716] Flag to enable redis advanced healthcheck

### DIFF
--- a/src/lua/api-gateway/redis/redisConnectionProvider.lua
+++ b/src/lua/api-gateway/redis/redisConnectionProvider.lua
@@ -110,7 +110,7 @@ function RedisConnectionProvider:connectToRedis(host, port, password, redisTimeo
     local times, error = redis:get_reused_times()
 
     if times and times ~= 0 then
-        ngx.log(ngx.DEBUG, "Reusing Redis connection")
+        ngx.log(ngx.DEBUG, "Reusing Redis connection. Reused times: " .. tostring(times))
         return true, redis
     end
 

--- a/src/lua/api-gateway/redis/redisHealthCheck.lua
+++ b/src/lua/api-gateway/redis/redisHealthCheck.lua
@@ -82,7 +82,7 @@ end
 local function isPeerHealthy(upstream, upstreamPassword)
 
     local performRedisAdvancedHealthcheck = ngx.var.redis_advanced_healthcheck
-    if not performRedisAdvancedHealthcheck or performRedisAdvancedHealthcheck == "nil" or performRedisAdvancedHealthcheck == "false" then
+    if not performRedisAdvancedHealthcheck or performRedisAdvancedHealthcheck == "" or performRedisAdvancedHealthcheck == "false" then
         ngx.log(ngx.DEBUG, "No advanced healthcheck, assuming peer is healthy: " .. tostring(upstream))
         return true
     end

--- a/src/lua/api-gateway/redis/redisHealthCheck.lua
+++ b/src/lua/api-gateway/redis/redisHealthCheck.lua
@@ -81,6 +81,12 @@ end
 -- instance may be down)
 local function isPeerHealthy(upstream, upstreamPassword)
 
+    local performRedisAdvancedHealthcheck = ngx.var.redis_advanced_healthcheck
+    if not performRedisAdvancedHealthcheck or performRedisAdvancedHealthcheck == "nil" or performRedisAdvancedHealthcheck == "false" then
+        ngx.log(ngx.DEBUG, "No advanced healthcheck, assuming peer is healthy: " .. tostring(upstream))
+        return true
+    end
+
     local authMessage = "AUTH "
     local successfulAuthResponse = "OK"
     local pingMessage = "PING\r\n"

--- a/src/lua/api-gateway/redis/redisHealthCheck.lua
+++ b/src/lua/api-gateway/redis/redisHealthCheck.lua
@@ -82,7 +82,7 @@ end
 local function isPeerHealthy(upstream, upstreamPassword)
 
     local enableRedisAdvancedHealthcheck = ngx.var.enable_redis_advanced_healthcheck
-    if not enableRedisAdvancedHealthcheck or enableRedisAdvancedHealthcheck ~= "true" then
+    if enableRedisAdvancedHealthcheck ~= "true" then
         ngx.log(ngx.DEBUG, "No advanced healthcheck, assuming peer is healthy: " .. tostring(upstream))
         return true
     end

--- a/src/lua/api-gateway/redis/redisHealthCheck.lua
+++ b/src/lua/api-gateway/redis/redisHealthCheck.lua
@@ -81,8 +81,8 @@ end
 -- instance may be down)
 local function isPeerHealthy(upstream, upstreamPassword)
 
-    local performRedisAdvancedHealthcheck = ngx.var.redis_advanced_healthcheck
-    if not performRedisAdvancedHealthcheck or performRedisAdvancedHealthcheck == "" or performRedisAdvancedHealthcheck == "false" then
+    local enableRedisAdvancedHealthcheck = ngx.var.enable_redis_advanced_healthcheck
+    if not enableRedisAdvancedHealthcheck or enableRedisAdvancedHealthcheck ~= "true" then
         ngx.log(ngx.DEBUG, "No advanced healthcheck, assuming peer is healthy: " .. tostring(upstream))
         return true
     end

--- a/test/unit-tests/api-gateway/redis/redisHealthCheckTest.lua
+++ b/test/unit-tests/api-gateway/redis/redisHealthCheckTest.lua
@@ -17,7 +17,7 @@ beforeEach(function()
         end
     }
 
-    shared = mock("ngx.shared", {"safe_set", "delete", "get"})
+    shared = mock("ngx.shared", { "safe_set", "delete", "get" })
     ngx.shared = {
         cachedOauthTokens = shared
     }
@@ -25,7 +25,6 @@ end)
 
 test('Successful flow with no password, should return one healthy host', function()
     local classUnderTest = require(CLASS_UNDER_TEST):new()
-
     ngxUpstreamMock.__get_primary_peers.doReturn = function()
         local primaryPeers = {}
         table.insert(primaryPeers, { name = "127.0.0.1:6379" })
@@ -115,6 +114,7 @@ test('Successful flow with password, should return one healthy host', function()
 end)
 
 test('Faulty flow with wrong password, should not return any host', function()
+    ngx.var["redis_advanced_healthcheck"] = "true"
     local classUnderTest = require(CLASS_UNDER_TEST):new()
     ngxUpstreamMock.__get_primary_peers.doReturn = function()
         local primaryPeers = {}
@@ -203,6 +203,7 @@ test('Backup peers successful flow with password, should return one healthy host
 end)
 
 test('Multiple peers successful flow with password, should return first healthy host', function()
+    ngx.var["redis_advanced_healthcheck"] = "true"
     local classUnderTest = require(CLASS_UNDER_TEST):new()
 
     local primaryPeers = {
@@ -257,6 +258,7 @@ test('Multiple peers successful flow with password, should return first healthy 
 end)
 
 test('No tcp connection should fail', function()
+    ngx.var["redis_advanced_healthcheck"] = "true"
     local classUnderTest = require(CLASS_UNDER_TEST):new()
 
     local primaryPeers = {

--- a/test/unit-tests/api-gateway/redis/redisHealthCheckTest.lua
+++ b/test/unit-tests/api-gateway/redis/redisHealthCheckTest.lua
@@ -114,7 +114,7 @@ test('Successful flow with password, should return one healthy host', function()
 end)
 
 test('Faulty flow with wrong password, should not return any host', function()
-    ngx.var["redis_advanced_healthcheck"] = "true"
+    ngx.var["enable_redis_advanced_healthcheck"] = "true"
     local classUnderTest = require(CLASS_UNDER_TEST):new()
     ngxUpstreamMock.__get_primary_peers.doReturn = function()
         local primaryPeers = {}
@@ -203,7 +203,7 @@ test('Backup peers successful flow with password, should return one healthy host
 end)
 
 test('Multiple peers successful flow with password, should return first healthy host', function()
-    ngx.var["redis_advanced_healthcheck"] = "true"
+    ngx.var["enable_redis_advanced_healthcheck"] = "true"
     local classUnderTest = require(CLASS_UNDER_TEST):new()
 
     local primaryPeers = {
@@ -258,7 +258,7 @@ test('Multiple peers successful flow with password, should return first healthy 
 end)
 
 test('No tcp connection should fail', function()
-    ngx.var["redis_advanced_healthcheck"] = "true"
+    ngx.var["enable_redis_advanced_healthcheck"] = "true"
     local classUnderTest = require(CLASS_UNDER_TEST):new()
 
     local primaryPeers = {


### PR DESCRIPTION
This PR enables the advanced TCP healthcheck (AUTH->PING/PONG) to be activated based on an nginx variable (`redis_advanced_healthcheck`) to help mitigate the `New connections` with too many open TCP connections.