### PR TITLE
Investigate "type of result is not correct userdata" token…

### DIFF
--- a/src/lua/api-gateway/validation/validator.lua
+++ b/src/lua/api-gateway/validation/validator.lua
@@ -121,6 +121,8 @@ function BaseValidator:getKeyFromRedis(key, hash_name)
         else
             if (type(result) == 'string') then
                 return result
+            elseif (result == ngx.null) then
+                ngx.log(ngx.WARN, "The value for the key " .. tostring(key) .. " is empty")
             else
                 ngx.log(ngx.WARN, "type of result is not correct " .. tostring(type(result)))
             end


### PR DESCRIPTION
… validation errors

This issue occurs for x-user-token (two token validation) and for service tokens.

It is reproducible with the following curl:

curl -H "Authorization: Bearer <valid_service_token>" -H "Host: api-mc-test-enhanced-automation-service-stage.adobe.io" -H "X-Api-Key: fail" http://localhost:9191/mandatory-service-token
{"error_code":"403201","message":"Client ID not allowed to call this service"}

Logs will now output:

2018/08/21 12:31:44 [warn] 59#0: *26 [lua] logger.lua:63: [...api-gateway/scripts/api-gateway/validation/validator.lua:127:getKeyFromRedis() req_id=mRtcgXILM2hvgwe9Y3uuFyrxzh1QkSty] The value for the key cachedwhitelist:api-mc-test-enhanced-automation-service:DigitalMarketingGateway2 is empty while sending to client, client: 172.18.0.1, server: api-mc-test-enhanced-automation-service-stage.adobe.io, request: "GET /mandatory-service-token HTTP/1.1", subrequest: "/validate_ims_token", host: "api-mc-test-enhanced-automation-service-stage.adobe.io"

Issue explaining why `ngx.null ` is used instead of plain nil. 
https://github.com/openresty/lua-resty-redis/issues/30

