### PR TITLE
Fix caching for profile validators 

### DIFF
--- a/src/lua/api-gateway/validation/oauth2/userProfileValidator.lua
+++ b/src/lua/api-gateway/validation/oauth2/userProfileValidator.lua
@@ -81,7 +81,7 @@ function _M:getCacheToken(token)
     end
 end
 
-function _M:getTokenCacheLookupKey()
+function _M:getCacheTokenLookupKey()
     local oauth_token = ngx.var.authtoken
     local oauth_token_hash = hasher.hash(oauth_token)
     return self:getCacheToken(oauth_token_hash)
@@ -96,7 +96,7 @@ function _M:getRedisCacheLookupProfileKey()
 end
 
 function _M:getLocalCacheLookupProfileKey()
-    local cacheLookupKey = self:getTokenCacheLookupKey()
+    local cacheLookupKey = self:getCacheTokenLookupKey()
     if self.PROFILE_VALIDATOR_CODE ~= nil and self.PROFILE_VALIDATOR_CODE ~= "" then
         return cacheLookupKey .. ":" .. self.PROFILE_VALIDATOR_CODE;
     else
@@ -213,7 +213,7 @@ end
 
 function _M:validateUserProfile()
     --1. try to get user's profile from the cache first ( local or redis cache )
-    local cacheTokenLookupKey = self:getTokenCacheLookupKey()
+    local cacheTokenLookupKey = self:getCacheTokenLookupKey()
     local cachedUserProfile = self:getProfileFromCache(cacheTokenLookupKey)
 
     if ( cachedUserProfile ~= nil ) then

--- a/src/lua/api-gateway/validation/oauth2/userProfileValidator.lua
+++ b/src/lua/api-gateway/validation/oauth2/userProfileValidator.lua
@@ -189,6 +189,17 @@ function _M:storeProfileInCache(cacheTokenLookupKey, cachingObj)
     self:setKeyInRedis(cacheTokenLookupKey, redisCacheLookupProfileKey, math.min(oauthTokenExpiration, (ngx.time() + default_ttl_expire) * 1000), cachingObjString)
 end
 
+---
+-- Deletes user profile from redis and local cache.
+--
+function _M:deleteProfileFromCache()
+    local localCacheLookupProfileKey = self:getLocalCacheLookupProfileKey()
+    self:deleteKeyInLocalCache(localCacheLookupProfileKey, self.USER_PROFILE_DICTIONARY)
+
+    local cacheTokenLookupKey = self:getCacheTokenLookupKey()
+    self:deleteKeyFromRedis(cacheTokenLookupKey)
+end
+
 --- Returns true if the profile is valid for the request context. If profile is not valid then it returns the failure
 -- status code and message.
 -- This method is to be overritten when this class is extended.


### PR DESCRIPTION
Description

Each validator stores its own set of data in cache but uses the same cache key, overwriting stored information necessary for request validation.
The data should be stored in cache in different entries for each profile validator flavour.


