### PR TITLE
Service level validator custom error responses affect all requests

### DIFF
--- a/src/lua/api-gateway/validation/validatorsHandlerErrorDecorator.lua
+++ b/src/lua/api-gateway/validation/validatorsHandlerErrorDecorator.lua
@@ -194,6 +194,7 @@ end
 -- hook to overwrite the DEFAULT_RESPONSES by specifying a jsonString
 function ValidatorHandlerErrorDecorator:setUserDefinedResponsesFromJson(jsonString)
     if (jsonString == nil or #jsonString < 2) then
+        user_defined_responses = nil
         return
     end
     local r = assert(cjson.decode(jsonString), "Invalid user defined jsonString:" .. tostring(jsonString))


### PR DESCRIPTION
Validator custom error responses defined at service level are propagated in all requests.
