### PR TITLE
Silence Dogstatsd logging

### DIFF
--- a/src/lua/api-gateway/dogstatsd/Dogstatsd.lua
+++ b/src/lua/api-gateway/dogstatsd/Dogstatsd.lua
@@ -41,7 +41,7 @@ local function getDogstatsd()
 
     local isDogstatsEnabled = ngx.var.isDogstatsEnabled
     if isDogstatsEnabled == nil or isDogstatsEnabled == "false" then
-        ngx.log(ngx.INFO, "dogstats module is disabled")
+        ngx.log(ngx.DEBUG, "dogstats module is disabled")
         return nil
     end
 


### PR DESCRIPTION
`dogstats module is disabled` should not be logged with every request in case the module is disabled