### PR TITLE
Make oauth local cache token ttl configurable

### DIFF
--- a/src/lua/api-gateway/validation/oauth2/oauthTokenValidator.lua
+++ b/src/lua/api-gateway/validation/oauth2/oauthTokenValidator.lua
@@ -211,7 +211,7 @@ function _M:validateOAuthToken()
             self:setContextProperties(obj)
             return ngx.HTTP_OK
         elseif (tokenValidity == 0) then
-            ngx.log(ngx.DEBUG, "Token still valid but about to expire in less than 1s")
+            ngx.log(ngx.DEBUG, "Token is still in the cache and it will expire in less than 1s")
         else
             -- at this point the cached token is not valid
             ngx.log(ngx.INFO, "Invalid OAuth Token found in cache. OAuth host=" .. tostring(oauth_host))

--- a/src/lua/api-gateway/validation/oauth2/oauthTokenValidator.lua
+++ b/src/lua/api-gateway/validation/oauth2/oauthTokenValidator.lua
@@ -143,11 +143,7 @@ function _M:extractContextVars(tokenInfo)
     cachingObj.oauth_token_scope = tokenInfo.token.scope
     cachingObj.oauth_token_client_id = tokenInfo.token.client_id
     cachingObj.oauth_token_user_id = tokenInfo.token.user_id
-    local oauth_token_expires_at = tokenInfo.expires_at
-    if ngx.var.max_auth_local_cache_ttl ~= nil and ngx.var.max_auth_local_cache_ttl ~= '' then
-        oauth_token_expires_at = math.min(oauth_token_expires_at, ngx.var.max_auth_local_cache_ttl * 1000)
-    end
-    cachingObj.oauth_token_expires_at = oauth_token_expires_at
+    cachingObj.oauth_token_expires_at = tokenInfo.expires_at -- NOTE: Assumption: value in ms
     return cachingObj
 end
 

--- a/src/lua/api-gateway/validation/oauth2/oauthTokenValidator.lua
+++ b/src/lua/api-gateway/validation/oauth2/oauthTokenValidator.lua
@@ -116,6 +116,9 @@ end
 
 function _M:storeTokenInCache(cacheLookupKey, cachingObj, expire_at_ms_utc)
     local expires_in_s = self:getExpiresIn(expire_at_ms_utc)
+    if ngx.var.max_auth_local_cache_ttl ~= nil and ngx.var.max_auth_local_cache_ttl ~= '' then
+        expires_in_s = math.min(expires_in_s, ngx.var.max_auth_local_cache_ttl)
+    end
     if (expires_in_s <= 0) then
         ngx.log(ngx.DEBUG, "OAuth Token was not persisted in the cache as it has expired at:" .. tostring(expire_at_ms_utc) .. ", while now is:" .. tostring(ngx.time() * 1000) .. " ms.")
         return nil


### PR DESCRIPTION
In case `max_oauth_local_cache_ttl` is defined, the oauth token should be locally cached with the value of `min(token.expires_in, ngx.var.max_oauth_local_cache_ttl)`

Also fixed a bug in the token validation logic that returns `INVALID_TOKEN` in the very last second of token validity. In this edge case, the token is still in the cache, but the `isCachedTokenValid` rounds the expires_in milliseconds to `0s`, considering the token expired, returning an `Invalid OAuth Token found in cache` error.   