### PR TITLE
fix: generalize the http status code returned to nginx when required

### DIFF
--- a/src/lua/api-gateway/validation/validator.lua
+++ b/src/lua/api-gateway/validation/validator.lua
@@ -291,6 +291,7 @@ function BaseValidator:exitFn(status, resp_body)
     ngx.status = self:convertToValidHttpStatusCode(status)
 
     if (ngx.null ~= resp_body) then
+        ngx.header["Content-Type"] = "application/json"
         ngx.say(resp_body)
     end
 

--- a/src/lua/api-gateway/validation/validator.lua
+++ b/src/lua/api-gateway/validation/validator.lua
@@ -255,6 +255,25 @@ function BaseValidator:executeTtl(key)
     end
 end
 
+-- converts a response status to a valid HTTP status code
+function BaseValidator:convertToValidHttpStatusCode(response_status)
+    response_status = tonumber(response_status)
+    if response_status == nil then
+        return 500
+    end
+    if (response_status >= 100 and response_status <= 599) then
+        return response_status
+    end
+
+    local http_code_str = string.sub(tostring(response_status), 1, 3)
+    local http_code_number = tonumber(http_code_str)
+    if http_code_number ~= nil and http_code_number >= 100 and http_code_number <= 599 then
+        return http_code_number
+    end
+
+    ngx.log(ngx.DEBUG, "Status code: ", tostring(response_status), " is not in a valid HTTP Status Code format")
+    return 500
+end
 
 -- generic exit function for a validator --
 function BaseValidator:exitFn(status, resp_body)
@@ -269,7 +288,7 @@ function BaseValidator:exitFn(status, resp_body)
         end
     end
 
-    ngx.status = status
+    ngx.status = self:convertToValidHttpStatusCode(status)
 
     if (ngx.null ~= resp_body) then
         ngx.say(resp_body)


### PR DESCRIPTION
In older OpenResty versions, NGINX was more lenient with invalid status codes.

In NGINX 1.27.1, it strictly validates that HTTP status codes must be between `100`-`599`, so codes emitted by the gateway (ie: `401013`) can cause unexpected failures
> ```[error] invalid HTTP status code 401013 while sending to client```

This fix is to replace a detailed status with it's generalization. For example: `401013` becomes `401`
