### PR TITLE
fix: Generalize response status code handling

### DIFF
--- a/src/lua/api-gateway/validation/validator.lua
+++ b/src/lua/api-gateway/validation/validator.lua
@@ -255,6 +255,25 @@ function BaseValidator:executeTtl(key)
     end
 end
 
+-- converts a response status to a valid HTTP status code
+function BaseValidator:convertToValidHttpStatusCode(response_status)
+    response_status = tonumber(response_status)
+    if response_status == nil then
+        return 500
+    end
+    if (response_status >= 100 and response_status <= 599) then
+        return response_status
+    end
+
+    local http_code_str = string.sub(tostring(response_status), 1, 3)
+    local http_code_number = tonumber(http_code_str)
+    if http_code_number ~= nil and http_code_number >= 100 and http_code_number <= 599 then
+        return http_code_number
+    end
+
+    ngx.log(ngx.DEBUG, "Status code: ", tostring(response_status), " is not in a valid HTTP Status Code format")
+    return 500
+end
 
 -- generic exit function for a validator --
 function BaseValidator:exitFn(status, resp_body)
@@ -269,7 +288,7 @@ function BaseValidator:exitFn(status, resp_body)
         end
     end
 
-    ngx.status = status
+    ngx.status = self:convertToValidHttpStatusCode(status)
 
     if (ngx.null ~= resp_body) then
         ngx.say(resp_body)


### PR DESCRIPTION
## Generalize response status code handling

### Summary

- **Normalize status codes sent to nginx**  
  In `validator.lua`, added `convertToValidHttpStatusCode()` so the value set to `ngx.status` is always a valid HTTP status (100–599). Extended codes (e.g. `401013`) are mapped to their 3-digit base (e.g. `401`); invalid or out-of-range values fall back to `500`. `exitFn` now uses this before setting `ngx.status`.

- **Support extended status in error decorator**  
  In `validatorsHandlerErrorDecorator.lua`, when the response template is looked up by status, a normalized status (e.g. `401`) may not match templates keyed by extended codes (e.g. `401013`). The decorator now falls back to parsing the response body JSON and using `error_code` for the lookup, so the correct template and custom response are still applied for extended error codes.

### Files changed

- `src/lua/api-gateway/validation/validator.lua` – status normalization and use in `exitFn`
- `src/lua/api-gateway/validation/validatorsHandlerErrorDecorator.lua` – fallback lookup by `error_code` from response body